### PR TITLE
Fix README code block termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ openssl pkcs12 -export \
   -inkey spm.key \
   -in spm.crt \
   -passout pass:YourPfxPassword
-````
+```
 
 * **Upload** `spm.crt` to Azure AD (public).
 * **Copy** `SharePointMirrorAuth.pfx` and note its password.
@@ -172,4 +172,3 @@ nssm start SharePointMirror
 * PRs welcome—follow existing code style.
 
 
-```


### PR DESCRIPTION
## Summary
- correct closing backtick count in certificate creation section
- remove stray backtick at end of README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684094cc67c0832c834d0ee1960e303e